### PR TITLE
GPU support for entropy calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,34 @@ y = get_descriptors(dset_y, k=k, cutoff=cutoff)
 dH = approx_delta_entropy(y, x, h=0.015, n=5, graph_neighbors=10)
 ```
 
+#### Computing the dataset entropy using PyTorch
+
+To accelerate the computation of entropy of datasets, one can use PyTorch to compute the entropy of a system.
+This can be done by first installing the optional dependencies for this repository:
+
+```bash
+pip install quests[gpu]
+```
+
+The syntax of the entropy, as computed with PyTorch, is identical to the one above.
+Instead of loading the functions from [quests.entropy](quests/entropy.py), however, you should load them from [quests.gpu.entropy](quests/gpu/entropy.py).
+The descriptors remain the same - as of now, creating descriptors using GPUs is not supported.
+Note that this constraint requires the descriptors to be generated using the traditional routes, and later converted into a `torch.tensor`.
+
+```python
+import torch
+from ase.io import read
+from quests.descriptor import get_descriptors
+from quests.gpu.entropy import perfect_entropy
+
+dset = read("dataset.xyz", index=":")
+x = get_descriptors(dset, k=32, cutoff=5.0)
+x = torch.tensor(x, device="cuda")
+h = 0.015
+batch_size = 10000
+H = perfect_entropy(x, h=h, batch_size=batch_size)
+```
+
 ### Citing
 
 If you use QUESTS in a publication, please cite the following paper:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,4 @@ packages = ["quests"]
 
 [project.optional-dependencies]
 docs = ["sphinx"]
+gpu = ["torch", "torchvision"]

--- a/quests/gpu/entropy.py
+++ b/quests/gpu/entropy.py
@@ -1,0 +1,145 @@
+import math
+
+import torch
+
+from .matrix import cdist, norm, sum_positive, sumexp, wsumexp
+
+DEFAULT_BANDWIDTH = 0.015
+DEFAULT_BATCH = 20000
+DEFAULT_UQ_NBRS = 3
+DEFAULT_GRAPH_NBRS = 10
+
+
+def perfect_entropy(
+    x: torch.tensor,
+    h: float = DEFAULT_BANDWIDTH,
+    batch_size: int = DEFAULT_BATCH,
+):
+    """Computes the perfect entropy of a dataset using a batch distance
+        calculation. This is necessary because the full distance matrix
+        often does not fit in the memory for a big dataset. This function
+        can be SLOW, despite the optimization of the computation, as it
+        does not approximate the results.
+
+    Arguments:
+        x (torch.tensor): an (N, d) matrix with the descriptors
+        h (int): bandwidth for the Gaussian kernel
+        batch_size (int): maximum batch size to consider when
+            performing a distance calculation.
+
+    Returns:
+        entropy (float): entropy of the dataset given by `x`.
+    """
+    N = x.shape[0]
+    p_x = kernel_sum(x, x, h=h, batch_size=batch_size)
+
+    # normalizes the p(x) prior to the log for numerical stability
+    p_x = torch.log(p_x / N)
+
+    return -torch.mean(p_x)
+
+
+def delta_entropy(
+    x: torch.tensor,
+    y: torch.tensor,
+    h: float = DEFAULT_BANDWIDTH,
+    batch_size: int = DEFAULT_BATCH,
+):
+    """Computes the differential entropy of a dataset `x` using the dataset
+        `y` as reference. This function can be SLOW, despite the optimization
+        of the computation, as it does not approximate the results.
+
+    Arguments:
+        x (torch.tensor): an (N, d) matrix with the descriptors of the test set
+        y (torch.tensor): an (N, d) matrix with the descriptors of the reference
+        h (int): bandwidth for the Gaussian kernel
+        batch_size (int): maximum batch size to consider when
+            performing a distance calculation.
+
+    Returns:
+        entropy (float): entropy of the dataset given by `x`.
+    """
+    p_x = kernel_sum(x, y, h=h, batch_size=batch_size)
+    return -torch.log(p_x)
+
+
+def diversity(
+    x: torch.tensor,
+    h: float = DEFAULT_BANDWIDTH,
+    batch_size: int = DEFAULT_BATCH,
+):
+    """Computes the diversity of a dataset `x` by assuming a sum over the
+        inverse p(x). This approximates the number of unique data points
+        in the system, as Kij >= 1 for a kernel matrix of a dataset.
+
+    Arguments:
+        x (torch.tensor): an (N, d) matrix with the descriptors of the dataset
+        h (int): bandwidth for the Gaussian kernel
+        batch_size (int): maximum batch size to consider when
+            performing a distance calculation.
+
+    Returns:
+        entropy (float): entropy of the dataset given by `x`.
+    """
+    p_x = kernel_sum(x, x, h=h, batch_size=batch_size)
+    return torch.sum(1 / p_x)
+
+
+def kernel_sum(
+    x: torch.tensor,
+    y: torch.tensor,
+    h: float = DEFAULT_BANDWIDTH,
+    batch_size: int = DEFAULT_BATCH,
+):
+    """Computes the kernel matrix K_ij for the descriptors x_i and y_j.
+        Because the entire matrix cannot fit in the memory, this function
+        automatically applies the kernel and sums the results, essentially
+        recovering the probability distribution p(x) up to a normalization
+        constant.
+
+    Arguments:
+        x (torch.tensor): an (M, d) matrix with the test descriptors
+        y (torch.tensor): an (N, d) matrix with the reference descriptors
+        h (int): bandwidth for the Gaussian kernel
+        batch_size (int): maximum batch size to consider when
+            performing a distance calculation.
+
+    Returns:
+        ki (torch.tensor): a (M,) vector containing the probability of x_i
+            given `y`
+    """
+    M = x.shape[0]
+    max_step_x = math.ceil(M / batch_size)
+
+    N = y.shape[0]
+    max_step_y = math.ceil(N / batch_size)
+
+    # precomputing the norms saves us some time
+    norm_x = norm(x)
+    norm_y = norm(y)
+
+    # variables that are going to store the results
+    p_x = torch.zeros(M, dtype=x.dtype)
+
+    # loops over rows and columns
+    for step_x in range(0, max_step_x):
+        i = step_x * batch_size
+        imax = min(i + batch_size, M)
+        x_batch = x[i:imax]
+        x_batch_norm = norm_x[i:imax]
+
+        # loops over all columns in batches to prevent memory overflow
+        for step_y in range(0, max_step_y):
+            j = step_y * batch_size
+            jmax = min(j + batch_size, N)
+            y_batch = y[j:jmax]
+            y_batch_norm = norm_y[j:jmax]
+
+            # computing the estimated probability distribution for the batch
+            z = cdist(x_batch, y_batch, x_batch_norm, y_batch_norm)
+            z = z / h
+            z = sumexp(-0.5 * (z**2))
+
+            p_x[i:imax] = p_x[i:imax] + z
+
+    return p_x

--- a/quests/gpu/entropy.py
+++ b/quests/gpu/entropy.py
@@ -119,7 +119,7 @@ def kernel_sum(
     norm_y = norm(y)
 
     # variables that are going to store the results
-    p_x = torch.zeros(M, dtype=x.dtype)
+    p_x = torch.zeros(M, dtype=x.dtype, device=x.device)
 
     # loops over rows and columns
     for step_x in range(0, max_step_x):

--- a/quests/gpu/matrix.py
+++ b/quests/gpu/matrix.py
@@ -1,0 +1,58 @@
+import torch
+
+
+def sum_positive(X):
+    return torch.clamp(X, min=0).sum(dim=1)
+
+
+def sumexp(X):
+    return torch.exp(X).sum(dim=1)
+
+
+def wsumexp(X, w):
+    return (w * torch.exp(X)).sum(dim=1)
+
+
+def logsumexp(X):
+    return torch.logsumexp(X, dim=1)
+
+
+def norm(A):
+    return torch.sum(A * A, dim=1)
+
+
+def cdist(A, B, norm_A=None, norm_B=None):
+    if norm_A is None:
+        norm_A = norm(A)
+    if norm_B is None:
+        norm_B = norm(B)
+    dist = torch.mm(A, B.t())
+    dist = -2 * dist + norm_A.unsqueeze(1) + norm_B.unsqueeze(0)
+    return torch.sqrt(torch.clamp(dist, min=0))
+
+
+def cdist_Linf(A, B):
+    return torch.cdist(A, B, p=float("inf"))
+
+
+def pdist(A):
+    return torch.pdist(A, p=2).square_().view(A.size(0), A.size(0))
+
+
+def argsort(X, sort_max=-1):
+    M, N = X.shape
+    if sort_max > 0:
+        M = sort_max
+    return torch.argsort(X[:M])
+
+
+def inverse_3d(matrix):
+    bx = torch.cross(matrix[1], matrix[2], dim=0)
+    by = torch.cross(matrix[2], matrix[0], dim=0)
+    bz = torch.cross(matrix[0], matrix[1], dim=0)
+    det = torch.dot(matrix[0], bx)
+    return torch.stack([bx / det, by / det, bz / det], dim=0)
+
+
+def stack_xyz(arrays):
+    return torch.stack(arrays)


### PR DESCRIPTION
This PR creates new functions for QUESTS to allow computing the entropy using GPUs. As the entropy calculation is essentially a giant matrix multiplication because of the kernels, it is reasonable to accelerate them with GPUs. The functions have been rewritten in PyTorch and a new module `quests.gpu` has been created. To avoid setting this as a requirement, the user can install PyTorch as optional dependencies and decide to import the GPU-enabled functions.

The results have been tested against one example dataset and the resulting entropy is the same. The new functions seem to have demonstrated improvement using the MPS backend compared to M3 CPUs. A complete benchmark has yet to be performed.