### PR TITLE
Vectorizing multibandwidth

### DIFF
--- a/quests/entropy.py
+++ b/quests/entropy.py
@@ -447,7 +447,7 @@ def approx_delta_entropy(
         for h_i in range(len_h):
             h0 = h[h_i]
             zm = d / h0
-            zm = sumexp(-0.5 * (zm**2)
+            zm = sumexp(-0.5 * (zm**2))
             p_y[h_i,:] = zm
 
     return -np.log(p_y)

--- a/quests/entropy.py
+++ b/quests/entropy.py
@@ -36,6 +36,7 @@ def perfect_entropy(
     N = x.shape[0]
     if type(h) is int or type(h) is float:
         p_x = kernel_sum(x, x, h=h, batch_size=batch_size)
+        # normalizes the p(x) prior to the log for numerical stability
         p_x = np.log(p_x / N)
         return -np.mean(p_x)
     else:
@@ -116,7 +117,7 @@ def kernel_sum(
     Arguments:
         x (np.ndarray): an (M, d) matrix with the test descriptors
         y (np.ndarray): an (N, d) matrix with the reference descriptors
-        h (int): bandwidth for the Gaussian kernel 
+        h (int): bandwidth for the Gaussian kernel
         batch_size (int): maximum batch size to consider when
             performing a distance calculation.
 
@@ -237,7 +238,7 @@ def weighted_kernel_sum(
     batch_size: int = DEFAULT_BATCH,
 ):
     """Computes the product w_j * K_ij for the descriptors x_i and y_j, and
-        a given weight w_j of same first dimension length as y_j.
+        a given weight w_j of same size as y_j. 
 
     Arguments:
         x (np.ndarray): an (M, d) matrix with the test descriptors

--- a/quests/entropy.py
+++ b/quests/entropy.py
@@ -46,32 +46,31 @@ def perfect_entropy(
 
 
 def delta_entropy(
-    x: np.ndarray,
     y: np.ndarray,
+    x: np.ndarray,
     h: float = DEFAULT_BANDWIDTH,
     batch_size: int = DEFAULT_BATCH,
 ):
-    """Computes the differential entropy of a dataset `x` using the dataset
-        `y` as reference. This function can be SLOW, despite the optimization
+    """Computes the differential entropy of a dataset `y` using the dataset
+        `x` as reference. This function can be SLOW, despite the optimization
         of the computation, as it does not approximate the results.
 
     Arguments:
-        x (np.ndarray): an (M, d) matrix with the descriptors of the test set
-        y (np.ndarray): an (N, d) matrix with the descriptors of the reference
+        y (np.ndarray): an (M, d) matrix with the descriptors of the test set
+        x (np.ndarray): an (N, d) matrix with the descriptors of the reference
         h (int or np.nadarray): bandwidth (value / vector) for the Gaussian kernel
         batch_size (int): maximum batch size to consider when
             performing a distance calculation.
 
     Returns:
-        entropy (np.ndarray): an (M,) vector of delta entropy between elements of
-        `x` given dataset 'y'.
+        dH (np.ndarray): an (M,) vector of differential entropy dH ( Y | X )
             or (np.ndarray): an (H,M) matrix if 'h' is a vector of length H
     """
     if type(h) is int or type(h) is float:
-        p_x = kernel_sum(x, y, h=h, batch_size=batch_size)
+        p_y = kernel_sum(y, x, h=h, batch_size=batch_size)
     else:
-        p_x = kernel_sum_multi_bandwidth(x, y, h=h, batch_size=batch_size)
-    return -np.log(p_x)
+        p_y = kernel_sum_multi_bandwidth(y, x, h=h, batch_size=batch_size)
+    return -np.log(p_y)
 
 
 def diversity(
@@ -407,21 +406,21 @@ def get_bandwidth(volume: float, method: str = "gaussian"):
 
 
 def approx_delta_entropy(
-    x: np.ndarray,
     y: np.ndarray,
+    x: np.ndarray,
     h: float = DEFAULT_BANDWIDTH,
     n: int = DEFAULT_UQ_NBRS,
     graph_neighbors: int = DEFAULT_GRAPH_NBRS,
     **kwargs,
 ):
-    """Computes an approximate differential entropy of a dataset `x` using the dataset
-        `y` as reference. This function was optimized to be FAST and multithreaded, but
+    """Computes an approximate differential entropy of a dataset `y` using the dataset
+        `x` as reference. This function was optimized to be FAST and multithreaded, but
         the recall may not be 100%. If recall is an issue, please consult the PyNNDescent
         documentation for the choice of keywords.
 
     Arguments:
-        x (np.ndarray): an (M, d) matrix with the descriptors of the test set
-        y (np.ndarray): an (N, d) matrix with the descriptors of the reference
+        y (np.ndarray): an (M, d) matrix with the descriptors of the test set
+        x (np.ndarray): an (N, d) matrix with the descriptors of the reference
         h (int or np.nadarray): bandwidth (value / vector) for the Gaussian kernel 
         k (int): number of nearest-neighbors to take into account when computing
             the approximate dH
@@ -432,22 +431,22 @@ def approx_delta_entropy(
     """
     import pynndescent as nnd
 
-    index = nnd.NNDescent(y, n_neighbors=graph_neighbors, **kwargs)
+    index = nnd.NNDescent(x, n_neighbors=graph_neighbors, **kwargs)
     index.prepare()
 
-    _, d = index.query(x, k=n)
+    _, d = index.query(y, k=n)
     if type(h) is int or type(h) is float:
         z = d / h
-        p_x = sumexp(-0.5 * z**2)
+        p_y = sumexp(-0.5 * z**2)
     else:
         # variables that are going to store the results
         len_h = h.shape[0]
-        imax = x.shape[0]
-        p_x = np.zeros((len_h,M), dtype=x.dtype)
+        imax = y.shape[0]
+        p_y = np.zeros((len_h,imax), dtype=y.dtype)
         for h_i in range(len_h):
             h0 = h[h_i]
             zm = d / h0
             zm = sumexp(-0.5 * (zm**2)
-            p_x[h_i,:] = zm
+            p_y[h_i,:] = zm
 
-    return -np.log(p_x)
+    return -np.log(p_y)

--- a/quests/matrix.py
+++ b/quests/matrix.py
@@ -6,15 +6,15 @@ import numpy as np
 
 @nb.njit(fastmath=True)
 def sum_positive(X):
-    """sumexp optimized for numba. Can lead to numerical
-        instabilities, but it's really fast.
+    """sumexp keeping only positive terms, optimized for numba. 
+        Can lead to numerical instabilities, but it's really fast.
 
     Arguments:
         X (np.ndarray): an (N, d) matrix with the values. The
             summation will happen over the axis 1.
 
     Returns:
-        sumexp (np.ndarray): sum(exp(X), axis=1)
+        sumexp (np.ndarray): (d,) matrix
     """
     result = np.empty(X.shape[0], dtype=X.dtype)
     for i in range(X.shape[0]):
@@ -33,11 +33,11 @@ def sumexp(X):
         instabilities, but it's really fast.
 
     Arguments:
-        X (np.ndarray): an (N, d) matrix with the values. The
+        X (np.ndarray): an (M, N) matrix with the values. The
             summation will happen over the axis 1.
 
     Returns:
-        sumexp (np.ndarray): sum(exp(X), axis=1)
+        sumexp (np.ndarray): (N,) matrix is sum(exp(X), axis=1)
     """
     result = np.empty(X.shape[0], dtype=X.dtype)
     for i in range(X.shape[0]):
@@ -56,9 +56,9 @@ def wsumexp(X, w):
         variable and can be unstable, but it's really fast.
 
     Arguments:
-        X (np.ndarray): an (N, d) matrix with the values. The
+        X (np.ndarray): an (M, N) matrix with the values. The
             summation will happen over the axis 1.
-        w (np.ndarray): a (d, ) vector with the weights.
+        w (np.ndarray): a (N, ) vector with the weights.
 
     Returns:
         wsumexp (np.ndarray): sum(w * exp(X), axis=1)
@@ -92,6 +92,14 @@ def logsumexp(X):
 
 @nb.njit(fastmath=True)
 def norm(A):
+    """Norm calculation
+
+    Arguments:
+        A (np.ndarray): an (N,d) matrix
+
+    Returns:
+        norm_A (np.ndarray): a (d,) vector of norms of rows of A
+    """ 
     norm_A = np.empty(A.shape[0], dtype=A.dtype)
     for i in range(A.shape[0]):
         _sum = 0.0
@@ -108,11 +116,12 @@ def cdist(A, B, norm_A=None, norm_B=None):
     """Optimized distance calculation using numba.
 
     Arguments:
-        A (np.ndarray): an (N, d) matrix with the descriptors
-        B (np.ndarray): an (M, d) matrix with the descriptors
+        A (np.ndarray): an (N, d1) float matrix with the descriptors
+        B (np.ndarray): an (M, d2) float matrix with the descriptors
 
     Returns:
-        dist (float): entropy of the dataset given by `x`.
+        dist (np.ndarray): a (M,N) float matrix of the
+                            distances between the descriptors.
     """
     # Computing the dot product
     dist = np.dot(A, B.T)

--- a/quests/matrix.py
+++ b/quests/matrix.py
@@ -6,7 +6,7 @@ import numpy as np
 
 @nb.njit(fastmath=True)
 def sum_positive(X):
-    """sum only positive terms, optimized for numba. 
+    """sum only positive terms, optimized for numba.
         Can lead to numerical instabilities, but it's really fast.
 
     Arguments:
@@ -37,7 +37,7 @@ def sumexp(X):
             summation will happen over the axis 1.
 
     Returns:
-        sumexp (np.ndarray): (N,) matrix is sum(exp(X), axis=1)
+        sumexp (np.ndarray): (M,) matrix is sum(exp(X), axis=1)
     """
     result = np.empty(X.shape[0], dtype=X.dtype)
     for i in range(X.shape[0]):
@@ -98,8 +98,8 @@ def norm(A):
         A (np.ndarray): an (N,d) matrix
 
     Returns:
-        norm_A (np.ndarray): a (d,) vector of norms of rows of A
-    """ 
+        norm_A (np.ndarray): a (N,) vector of norms of rows of A
+    """
     norm_A = np.empty(A.shape[0], dtype=A.dtype)
     for i in range(A.shape[0]):
         _sum = 0.0
@@ -120,7 +120,7 @@ def cdist(A, B, norm_A=None, norm_B=None):
         B (np.ndarray): an (M, d2) float matrix with the descriptors
 
     Returns:
-        dist (np.ndarray): a (N,M) float matrix of the
+        dist (np.ndarray): a (N, M) float matrix of the
                             distances between the descriptors.
     """
     # Computing the dot product
@@ -155,7 +155,7 @@ def cdist_Linf(A, B):
         B (np.ndarray): an (M, d) matrix with the descriptors
 
     Returns:
-        dist (np.ndarray): distance matrix
+        dist (np.ndarray): (N, M) distance matrix
     """
     # Computing the dot product
     M = A.shape[0]

--- a/quests/matrix.py
+++ b/quests/matrix.py
@@ -6,7 +6,7 @@ import numpy as np
 
 @nb.njit(fastmath=True)
 def sum_positive(X):
-    """sumexp keeping only positive terms, optimized for numba. 
+    """sum only positive terms, optimized for numba. 
         Can lead to numerical instabilities, but it's really fast.
 
     Arguments:
@@ -14,7 +14,7 @@ def sum_positive(X):
             summation will happen over the axis 1.
 
     Returns:
-        sumexp (np.ndarray): (d,) matrix
+        sumexp (np.ndarray): (d,) matrix is sum(max(X,0), axis=1)
     """
     result = np.empty(X.shape[0], dtype=X.dtype)
     for i in range(X.shape[0]):
@@ -120,7 +120,7 @@ def cdist(A, B, norm_A=None, norm_B=None):
         B (np.ndarray): an (M, d2) float matrix with the descriptors
 
     Returns:
-        dist (np.ndarray): a (M,N) float matrix of the
+        dist (np.ndarray): a (N,M) float matrix of the
                             distances between the descriptors.
     """
     # Computing the dot product


### PR DESCRIPTION
-Created new sister functions kernel_sum_multi_bandwidth and weighted_kernel_sum_multi_bandwidth that accept h as a 1d np.ndarray of length H and return (H,M) matrices instead of (M, ) vectors
-Added support to the rest of the functions in entropy.py (perfect_entropy, delta_entropy, diversity, approx_delta_entropy) to accept h as either a float (current behavior) or as a 1d np.ndarray of length H in which case they return an (H, ) matrix instead of a single float or an (H, M) matrix instead of an (M, ) matrix. 
-Updated some documentation of functions where missing or outdated