### PR TITLE
Multicomponent QUESTS descriptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,32 @@ D = diversity(x, h=h, batch_size=batch_size)
 
 In this example, descriptors are being created using 32 nearest neighbors and a 5.0 Å cutoff.
 The entropy and diversity are being computed using a Gaussian kernel (default) with bandwidth of 0.015 1/Å and batch size of 10,000.
+For multicomponent systems, see below.
+
+#### Computing descriptors for multicomponent systems
+
+As of the current version, QUESTS allow you to compute a simplified descriptor for multi-element systems.
+The descriptor is made by the concatenation of normal QUESTS descriptors, and the same descriptor computed on a per-element basis.
+For instance, for a hypothetical A-B alloy, we first compute the descriptors on a per-environment basis without regard for composition.
+Then, we compute it two more times: one considering that only atoms A exist, then later considering that only atoms B exist.
+The final descriptor is made by the concatenation of these three descriptors.
+For N elements, the final length of the descriptor is (N + 1) * k * (k + 1) / 2, where k is the number of neighbors passed as a parameter.
+
+```python
+from ase.io import read
+from quests.descriptor import get_descriptors_multicomponent
+from quests.entropy import perfect_entropy, diversity
+
+dset = read("dataset.xyz", index=":")
+species = ["Ag", "Au"]  # if not provided, species will be inferred from the dataset
+x = get_descriptors_multicomponent(dset, k=32, cutoff=5.0, species=species)
+```
+
+Like in the example before, descriptors are being created using 32 nearest neighbors and a 5.0 Å cutoff.
+Please note: as of now, the rule for the selection of the bandwidth is still being tested.
+In principle, however, all the other functions for QUESTS are still compatible with the multicomponent descriptors.
+
+⚠️ Note: This feature is under construction and is subject to change
 
 #### Computing differential entropies
 

--- a/README.md
+++ b/README.md
@@ -255,12 +255,15 @@ Data and notebooks to reproduce the results from the paper are available on Zeno
 If you use QUESTS in a publication, please cite the following paper:
 
 ```bibtex
-@article{schwalbekoda2024information,
-    title = {Model-free quantification of completeness, uncertainties, and outliers in atomistic machine learning using information theory},
+@article{schwalbekoda2025information,
+    title = {Model-free estimation of completeness, uncertainties, and outliers in atomistic machine learning using information theory},
     author = {Schwalbe-Koda, Daniel and Hamel, Sebastien and Sadigh, Babak and Zhou, Fei and Lordi, Vincenzo},
-    year = {2024},
-    journal = {arXiv:2404.12367},
-    url = {https://arxiv.org/abs/2404.12367},
+    year = {2025},
+    journal = {Nature Communications},
+    url = {https://doi.org/10.1038/s41467-025-59232-0},
+    doi = {10.1038/s41467-025-59232-0},
+    volume={16},
+    pages={4014},
 }
 ```
 ## License

--- a/quests/descriptor.py
+++ b/quests/descriptor.py
@@ -390,6 +390,8 @@ def get_descriptors_multicomponent(
         `dset` and a list of species. The computation of atom-centered descriptors is parallelized over
         the maximum number of threads set by numba.
 
+    NOTICE: This is under testing and may be subject to changes!
+
     Arguments:
         dset (List[Atoms]): dataset for which the descriptors will be computed.
         k (int): number of nearest neighbors to use when computing descriptors.
@@ -412,7 +414,7 @@ def get_descriptors_multicomponent(
 
     species = sorted(species)
     n_species = len(species)
-            
+
     x1, x2 = [], []
     for atoms in dset:
         _x1, _x2 = [], []

--- a/quests/descriptor.py
+++ b/quests/descriptor.py
@@ -376,3 +376,90 @@ def get_descriptors(
         return np.concatenate([x1, x2], axis=1)
 
     return x1, x2
+
+
+def get_descriptors_multicomponent(
+    dset: List[Atoms],
+    k: int = DEFAULT_K,
+    cutoff: float = DEFAULT_CUTOFF,
+    species: List[str] = None,
+    concat: bool = True,
+    dtype: str = "float32",
+):
+    """Computes the multicomponent representation for the QUESTS approach given a dataset
+        `dset` and a list of species. The computation of atom-centered descriptors is parallelized over
+        the maximum number of threads set by numba.
+
+    Arguments:
+        dset (List[Atoms]): dataset for which the descriptors will be computed.
+        k (int): number of nearest neighbors to use when computing descriptors.
+        cutoff (float): cutoff radius for the weight function.
+        species (List[str]): list of chemical symbols to be used for the multicomponent
+            representation of QUESTS. If not given, uses all the different species in
+            the dataset `dset`.
+        concat (bool): if True, concatenates X1 and X2 column-wise and returns a
+            single matrix X.
+        dtype (str): dtype for the matrix.
+
+    Returns:
+        X (np.ndarray): matrix containing descriptors for all atoms in `dset`.
+    """
+    if species is None:
+        species = []
+        for atoms in dset:
+            species += list(set(atoms.get_chemical_symbols()))
+        species = list(set(species))
+
+    n_species = len(species)
+            
+    x1, x2 = [], []
+    for atoms in dset:
+        _x1, _x2 = [], []
+        full_x1, full_x2 = descriptor_pbc(
+            atoms.positions, cell=np.array(atoms.cell), k=k, cutoff=cutoff
+        )
+        _x1.append(full_x1)
+        _x2.append(full_x2)
+
+        if n_species > 1:
+            symbols = atoms.get_chemical_symbols()
+            for sp in species:
+                idx = np.array([sym == sp for sym in symbols])
+                part_x1, part_x2 = descriptor_pbc(
+                    atoms.positions[idx], cell=np.array(atoms.cell), k=k, cutoff=cutoff
+                )
+                _part_x1 = np.zeros_like(full_x1)
+                _part_x2 = np.zeros_like(full_x2)
+                _part_x1[idx] = part_x1
+                _part_x2[idx] = part_x2
+
+                _x1.append(_part_x1)
+                _x2.append(_part_x2)
+
+            _x1 = np.concatenate(_x1, axis=1)
+            _x2 = np.concatenate(_x2, axis=1)
+
+        x1.append(_x1)
+        x2.append(_x2)
+
+    x1 = np.concatenate(x1)
+    x2 = np.concatenate(x2)
+
+    x1 = x1.astype(dtype)
+    x2 = x2.astype(dtype)
+
+    if concat:
+        if n_species == 1:
+            return np.concatenate([x1, x2], axis=1)
+
+        len1 = k * (n_species + 1)
+        len2 = (k - 1) * (n_species + 1)
+
+        x = []
+        for i in range(n_species + 1):
+            x.append(x1[:, i * len1 : (i + 1) * len1])
+            x.append(x2[:, i * len2 : (i + 1) * len2])
+
+        return np.concatenate(x, axis=1)
+
+    return x1, x2

--- a/quests/descriptor.py
+++ b/quests/descriptor.py
@@ -410,6 +410,7 @@ def get_descriptors_multicomponent(
             species += list(set(atoms.get_chemical_symbols()))
         species = list(set(species))
 
+    species = sorted(species)
     n_species = len(species)
             
     x1, x2 = [], []
@@ -421,6 +422,7 @@ def get_descriptors_multicomponent(
         _x1.append(full_x1)
         _x2.append(full_x2)
 
+        # descriptors on a per-species are only A-A, B-B type of interactions
         if n_species > 1:
             symbols = atoms.get_chemical_symbols()
             for sp in species:
@@ -448,6 +450,7 @@ def get_descriptors_multicomponent(
     x1 = x1.astype(dtype)
     x2 = x2.astype(dtype)
 
+    # sort the descriptors to obtain (x1, x2) pairs in a per-species manner
     if concat:
         if n_species == 1:
             return np.concatenate([x1, x2], axis=1)

--- a/quests/tools/example.py
+++ b/quests/tools/example.py
@@ -1,3 +1,4 @@
+import random
 import numpy as np
 from ase.build import bulk, make_supercell
 
@@ -27,3 +28,25 @@ def get_noisy_structures(frac=1.0, noise=0.05, supercell_size=6):
     shcp.translate(noise * np.random.randn(len(shcp), 3))
 
     return sfcc, sbcc, shcp
+
+
+def get_multicomponent_structures(frac=1.0, supercell=1, ratio=0.5, seed: int = None):
+    fcc = bulk("Au", "fcc", a=frac * 4.08)
+    bcc = bulk("Au", "bcc", a=frac * 3.31)
+    hcp = bulk("Au", "hcp", a=frac * 2.88)
+
+    if supercell > 1:
+        fcc = make_supercell(fcc, np.eye(3) * supercell)
+        bcc = make_supercell(bcc, np.eye(3) * supercell)
+        hcp = make_supercell(hcp, np.eye(3) * supercell)
+
+    if seed is not None:
+        random.seed(seed)
+
+    for struct in [fcc, bcc, hcp]:
+        indices = list(range(len(struct)))
+        selected = random.sample(indices, k=int(ratio * len(struct)))
+        for i in selected:
+            struct[i].symbol = "Ag"
+
+    return fcc, bcc, hcp


### PR DESCRIPTION
Introduces support for computing descriptors for multicomponent systems in the QUESTS framework, updates the project documentation to reflect this new capability, and adds a utility function for generating example multicomponent structures. The changes also update the project citation to reference the published journal article.

**New features for multicomponent systems:**

* Added a new function `get_descriptors_multicomponent` in `quests/descriptor.py` to compute concatenated descriptors for systems containing multiple atomic species, supporting both per-environment and per-element representations. This function is currently experimental and its interface may change.
* Added a utility function `get_multicomponent_structures` in `quests/tools/example.py` to generate example structures with multiple atomic species, facilitating testing and demonstration of the new descriptor functionality.

**Documentation updates:**

* Expanded the `README.md` with a new section describing how to compute descriptors for multicomponent systems, including usage examples and notes about the current experimental status.
* Updated the project citation in `README.md` to reference the published Nature Communications article instead of the previous arXiv preprint, including updated bibliographic details and DOI.

**Miscellaneous:**

* Added a missing import of the `random` module in `quests/tools/example.py` to support random sampling in the new utility function.