### PR TITLE
Use h and batch size in kernel sum in MSC function

### DIFF
--- a/quests/compression/fps.py
+++ b/quests/compression/fps.py
@@ -115,7 +115,7 @@ def msc(
         )
 
         # compute the kernel between the remaining environments and the last one
-        remaining_kernels += kernel_sum(remaining_x, last_x)
+        remaining_kernels += kernel_sum(remaining_x, last_x, h=h, batch_size=batch_size)
 
         # now, define the value of the kernel in a greedy way, saying that the
         # kernel of a structure is equal to the furthest environment towards


### PR DESCRIPTION
Hello there,

I'd like to use the MSC function in some of my work, but wanted to update the bandwidth to be more tailored to liquid water. I noticed that `msc` has an option to set the bandwidth but doesn't actually use it in the kernel sum. This PR should be a quick fix. Keep up the good work!

Cheers,
Lucas
