### PR TITLE
Compress condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,55 @@ summary = compressor.get_summary(selected)
 print(summary)
 ```
 
+#### Conditional compression with reference datasets
+
+QUESTS also supports conditional compression, which allows you to select structures that are most informative *given* a reference dataset. This is useful when you want to incrementally build a compressed dataset or select new data points that complement an existing dataset.
+
+To use conditional compression with the command-line interface:
+
+```bash
+quests compress new_data.xyz -r reference.xyz -s 100 -o results.json
+```
+
+This command will:
+1. Load the reference dataset from `reference.xyz`
+2. Select 100 structures from `new_data.xyz` that are most informative given the reference
+3. Automatically use the `msc_conditional` method
+4. Save the results to `results.json`
+
+The `-s` parameter can also be a fraction (e.g., `-s 0.3` for 30% of the dataset).
+
+Using the API for conditional compression:
+
+```python
+from ase.io import read
+from quests.compression import DatasetCompressor
+
+# Load the candidate dataset and the reference dataset
+candidates = read("new_data.xyz", index=":")
+reference = read("reference.xyz", index=":")
+
+# Create compressor for the candidate dataset
+compressor = DatasetCompressor(candidates)
+
+# Compute descriptors for the reference dataset using the same parameters
+ref_descriptors = compressor.descriptors(reference)
+
+# Select 100 structures that complement the reference dataset
+selected = compressor.get_indices(
+    method="msc_conditional",
+    size=100,
+    reference=ref_descriptors
+)
+
+# Get metrics about the combined dataset
+summary = compressor.get_summary(selected)
+print(summary)
+```
+
+The conditional compression method starts with the reference descriptors and ensures that newly selected structures provide maximal information gain relative to what is already known from the reference dataset.
+This approach is particularly useful for active learning or multi-stage compression.
+
 ### Demonstration
 
 One example demonstrating the use of QUESTS for computing the entropy of the Carbon GAP-20 dataset is provided under the folder `examples`.

--- a/quests/compression/compress.py
+++ b/quests/compression/compress.py
@@ -153,7 +153,7 @@ class DatasetCompressor:
         self._check_compression_method(method)
         compress_fn = METHODS[method]
 
-        if method == "msc":
+        if method in ("msc", "msc_conditional"):
             kwargs = {
                 **kwargs,
                 "h": self.bandwidth,

--- a/quests/compression/compress.py
+++ b/quests/compression/compress.py
@@ -47,7 +47,23 @@ class DatasetCompressor:
         self._entropies = np.array(
             [entropy(x, h=bandwidth, batch_size=batch_size) for x in self._descriptors]
         )
+        
+    def descriptors(self, selected: List[int] = None):
+        if selected is None:
+            return self._descriptors
+        
+        if not isinstance(selected, list):
+            raise ValueError("selected has to be a list of indices or atoms")
 
+        if len(selected) == 0:
+            return []
+        
+        if isinstance(selected[0], Atoms):
+            return [self.descriptor_fn(at) for at in selected]
+        
+        else:
+            return [self._descriptors[i] for i in selected]
+        
     def entropy(self, selected: List[int] = None):
         if selected is None:
             data = np.concatenate(self._descriptors, axis=0)

--- a/quests/compression/compress.py
+++ b/quests/compression/compress.py
@@ -13,12 +13,13 @@ from quests.entropy import (
 )
 
 from .baseline import k_means, mean_fps, random_sample
-from .fps import fps, msc
+from .fps import fps, msc, msc_conditional
 
 EPSILON = 1e-5
 METHODS = {
     "fps": fps,
     "msc": msc,
+    "msc_conditional": msc_conditional,
     "random": random_sample,
     "mean_fps": mean_fps,
     "k_means": k_means,

--- a/quests/compression/fps.py
+++ b/quests/compression/fps.py
@@ -25,7 +25,7 @@ SELECT_FNS = {
 
 
 def fps(
-    descriptors: List[np.ndarray], entropies: np.ndarray, size: int, method: str = "fps"
+    descriptors: List[np.ndarray], entropies: np.ndarray, size: int, method: str = "fps", **kwargs
 ) -> List[int]:
     # select the sampling strategy
     assert method in SELECT_FNS, f"Method {method} not supported"

--- a/quests/compression/fps.py
+++ b/quests/compression/fps.py
@@ -137,3 +137,94 @@ def msc(
         compressed.append(next_i)
 
     return compressed
+
+
+def msc_conditional(
+    descriptors: List[np.ndarray],
+    entropies: np.ndarray,
+    size: int,
+    reference: List[np.ndarray],
+    h: float = DEFAULT_BANDWIDTH,
+    batch_size: int = DEFAULT_BATCH,
+) -> List[int]:
+    """Compresses the dataset conditionally on a reference set of descriptors.
+    
+    This function selects the most informative structures from `descriptors`
+    given that the `reference` descriptors have already been selected. This is
+    useful for incrementally building a compressed dataset or for selecting
+    new data points that complement an existing dataset.
+    
+    The algorithm initializes the kernel accumulator using the reference
+    descriptors, then iteratively selects structures that are both novel
+    (low kernel similarity to reference and already selected) and diverse
+    (high entropy).
+    
+    Args:
+        descriptors: List of descriptor arrays for candidate structures.
+        entropies: Array of entropies for each candidate structure.
+        size: Number of structures to select from the candidates.
+        reference: List of descriptor arrays from previously compressed dataset.
+        h: Bandwidth parameter for kernel computation.
+        batch_size: Batch size for kernel computation.
+    
+    Returns:
+        List of indices of the selected structures from the candidates.
+    """
+    if len(descriptors) == 0:
+        return []
+
+    if size <= 0:
+        return []
+
+    # all candidates start as remaining
+    remaining = list(range(len(descriptors)))
+    entropies = entropies.tolist()
+
+    # we will use the pre-computed descriptors for all candidates
+    remaining_x = np.concatenate([descriptors[i] for i in remaining])
+
+    # initialize the kernel accumulator using the reference descriptors
+    # this accounts for the similarity to the already compressed dataset
+    remaining_kernels = np.zeros(len(remaining_x))
+    for ref_x in reference:
+        remaining_kernels += kernel_sum(remaining_x, ref_x, h=h, batch_size=batch_size)
+
+    compressed = []
+    size = min(size, len(descriptors))
+
+    while len(compressed) < size:
+        # create matrices to track which environments belong to which structure
+        remaining_natoms = np.array([len(descriptors[i]) for i in remaining])
+
+        # this creates an array that explains which environments belong to
+        # each index in `remaining`
+        remaining_idx = np.concatenate(
+            [np.full(n, fill_value=i) for i, n in enumerate(remaining_natoms)]
+        )
+
+        # define the value of the kernel in a greedy way, saying that the
+        # kernel of a structure is equal to the furthest environment towards
+        # the entire dataset (reference + already selected)
+        per_struct_kernels = np.array(
+            [remaining_kernels[remaining_idx == n].min() for n in range(len(remaining))]
+        )
+
+        # select the environment that both maximizes the dH = -np.log(K) and
+        # is diverse enough that the entropy is large
+        per_struct_dH = -np.log(per_struct_kernels)
+        selected = (per_struct_dH + np.array(entropies)).argmax()
+
+        # update the loop and the set of compressed data
+        next_i = remaining.pop(selected)
+        entropies.pop(selected)
+        compressed.append(next_i)
+
+        # if we have more to select, update the kernels for the remaining
+        if len(compressed) < size:
+            # compute the kernel contribution from the newly selected structure
+            last_x = descriptors[next_i]
+            remaining_x = remaining_x[remaining_idx != selected]
+            remaining_kernels = remaining_kernels[remaining_idx != selected]
+            remaining_kernels += kernel_sum(remaining_x, last_x, h=h, batch_size=batch_size)
+
+    return compressed

--- a/quests/compression/fps.py
+++ b/quests/compression/fps.py
@@ -175,6 +175,10 @@ def msc_conditional(
 
     if size <= 0:
         return []
+    
+    if len(reference) == 0:
+        # if no reference is provided, fall back to standard msc
+        return msc(descriptors, entropies, size, h=h, batch_size=batch_size)
 
     # all candidates start as remaining
     remaining = list(range(len(descriptors)))


### PR DESCRIPTION
This pull request adds support for conditional compression in the QUESTS dataset compression tool. Conditional compression allows users to select new structures that are most informative given an existing reference dataset, which is particularly useful for incremental dataset building and active learning workflows.

**New feature: Conditional compression**
- Added a new `msc_conditional` method for selecting structures that complement a reference dataset, both in the core API and the CLI. [[1]](diffhunk://#diff-33cc93440426e0b997d3ed2b343872d69552a6b6e4364a5f24b1bd5402530070R140-R234) [[2]](diffhunk://#diff-b19b73e351f253d29b2e25ab3ca452410dd98688f60d9a1212f5eb0e4f6c17afL16-R22)

**Command-line interface enhancements**
- Introduced a new `--reference` (`-r`) option to the `compress` CLI command, enabling users to specify a reference dataset for conditional compression. When used, the CLI automatically switches to the `msc_conditional` method. [[1]](diffhunk://#diff-33dad7c9bd0bf1abca546af32be1cd0282336125fe772c8d9540c047b95eaff2R20-R26) [[2]](diffhunk://#diff-33dad7c9bd0bf1abca546af32be1cd0282336125fe772c8d9540c047b95eaff2R91) [[3]](diffhunk://#diff-33dad7c9bd0bf1abca546af32be1cd0282336125fe772c8d9540c047b95eaff2R109-R114)
- Updated CLI logic to load reference datasets, compute their descriptors, and pass them to the compression method as needed.
- Modified CLI output to include the reference dataset in the results.

**Documentation updates**
- Expanded the `README.md` with a new section explaining conditional compression, including CLI and API usage examples and a description of the use cases for this feature.